### PR TITLE
137 onboarding pallet get houses with onboarded status

### DIFF
--- a/pallets/onboarding/src/benchmarking.rs
+++ b/pallets/onboarding/src/benchmarking.rs
@@ -16,5 +16,5 @@ benchmarks! {
 		assert_eq!(Something::<T>::get(), Some(s));
 	}
 
-	impl_benchmark_test_suite!(Onboarding, crate::mock::new_test_ext(), crate::mock::Test);
+	impl_benchmark_test_suite!(Onboarding, crate::mock::ExtBuilder::default().build(), crate::mock::Test);
 }

--- a/pallets/onboarding/src/functions.rs
+++ b/pallets/onboarding/src/functions.rs
@@ -103,4 +103,8 @@ impl<T: Config> Pallet<T> {
 	pub fn account_id() -> T::AccountId {
 		T::FeesAccount::get().into_account_truncating()
 	}
+
+	pub fn get_onboarded_houses() -> Vec<(<T as pallet_nft::Config>::NftCollectionId, <T as pallet_nft::Config>::NftItemId, types::Asset<T>)> {
+		Houses::<T>::iter().filter(|val| val.2.status == types::AssetStatus::ONBOARDED).map(|elt| (elt.0, elt.1, elt.2)).collect()
+	}
 }


### PR DESCRIPTION
A new function has been added and exposed in the Onboarding pallet.
It allows the Bidding pallet to retrieve asset with `onboarded` status without using the acual storage getter `houses()` that requires arguments to get data.
We should have needed to call `houses()` with some arguments before filtering the assets by status. Here a call to `get_onboaded_houses()` gives directly assets with `onboarded` status.
The tests has been updated accordingly.