### PR TITLE
Workflow_1 completed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1373,6 +1373,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-iterator"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91a4ec26efacf4aeff80887a175a419493cb6f8b5480d26387eb0bd038976187"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "828de45d0ca18782232dfb8f3ea9cc428e8ced380eb26a520baaacfc70de39ce"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "enumflags2"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4356,8 +4376,10 @@ dependencies = [
  "frame-support",
  "frame-system",
  "pallet-balances",
+ "pallet-nft",
  "pallet-roles",
  "pallet-sudo",
+ "pallet-uniques",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
@@ -4424,6 +4446,7 @@ dependencies = [
 name = "pallet-nft"
 version = "4.0.0"
 dependencies = [
+ "enum-iterator",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -4647,6 +4670,7 @@ dependencies = [
 name = "pallet-share_distributor"
 version = "4.0.0-dev"
 dependencies = [
+ "enum-iterator",
  "frame-benchmarking",
  "frame-support",
  "frame-system",

--- a/pallets/housing_fund/src/lib.rs
+++ b/pallets/housing_fund/src/lib.rs
@@ -93,7 +93,7 @@ pub mod pallet {
 	#[pallet::storage]
 	#[pallet::getter(fn reservations)]
 	// Housing fund reservations
-	pub(super) type Reservations<T> =
+	pub type Reservations<T> =
 		StorageMap<_, Blake2_128Concat, (NftCollectionId<T>, NftItemId<T>), FundOperation<T>, OptionQuery>;
 
 	#[pallet::storage]

--- a/pallets/nft/Cargo.toml
+++ b/pallets/nft/Cargo.toml
@@ -13,6 +13,7 @@ repository = "https://github.com/Fair-Squares/fair-squares"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
+enum-iterator = "1.2.0"
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [
 	"derive",
 ] }

--- a/pallets/nft/src/benchmarking.rs
+++ b/pallets/nft/src/benchmarking.rs
@@ -118,7 +118,7 @@ benchmarks! {
         let caller2 = create_account::<T>("caller2", 1);
         let caller2_lookup = T::Lookup::unlookup(caller2.clone());
         do_mint::<T>(caller3.clone());
-    }: _(RawOrigin::Signed(caller1), PossibleCollections::HOUSESTEST, 0u32.into(), caller2_lookup)
+    }: _(RawOrigin::Root, PossibleCollections::HOUSESTEST, 0u32.into(), caller2_lookup)
     verify {
         assert_eq!(UNQ::Pallet::<T>::owner(T::NftCollectionId::from(COLLECTION_ID_0).into(), T::NftItemId::from(0u32).into()), Some(caller2));
     }

--- a/pallets/nft/src/lib.rs
+++ b/pallets/nft/src/lib.rs
@@ -42,7 +42,7 @@ use frame_support::{
 	traits::{tokens::nonfungibles::*, Get},
 	transactional, BoundedVec,
 };
-use frame_system::ensure_signed;
+use frame_system::{ensure_signed,ensure_root};
 use pallet_uniques::DestroyWitness;
 
 pub use functions::*;
@@ -237,7 +237,7 @@ pub mod pallet {
 			Ok(())
 		}
 
-		/// Triggered by a servicer(`origin`), this transfers NFT from owner account to `dest` account
+		/// Triggered by Root(`origin`), this transfers NFT from owner account to `dest` account
 		///
 		/// Parameters:
 		/// - `collection_id`: The Collection of the asset to be transferred.
@@ -251,10 +251,8 @@ pub mod pallet {
 			item_id: T::NftItemId,
 			dest: <T::Lookup as StaticLookup>::Source,
 		) -> DispatchResult {
-			//the transaction is triggered by a servicer
-			let sender = ensure_signed(origin)?;
-			let triggered_by = Roles::Pallet::<T>::get_roles(&sender).unwrap();
-			ensure!(T::Permissions::can_transfer(&triggered_by), Error::<T>::NotPermitted);
+			//the transaction is triggered by Root
+			ensure_root(origin)?;
 
 			//Nft transfered from old to new owner
 			let coll_id: CollectionId = collection_id.value();

--- a/pallets/nft/src/mock.rs
+++ b/pallets/nft/src/mock.rs
@@ -54,10 +54,6 @@ impl NftPermission<Acc> for NftTestPermissions {
 		matches!(*created_by, Acc::SELLER)
 	}
 
-	fn can_transfer(created_by: &Acc) -> bool {
-		matches!(*created_by, Acc::SERVICER)
-	}
-
 	fn can_burn(created_by: &Acc) -> bool {
 		matches!(*created_by, Acc::SERVICER)
 	}

--- a/pallets/nft/src/tests.rs
+++ b/pallets/nft/src/tests.rs
@@ -154,10 +154,12 @@ fn transfer_works() {
 			metadata
 		));
 
+		let origin: Origin= frame_system::RawOrigin::Root.into();
+
 		// not existing
 		assert_noop!(
 			NFTPallet::transfer(
-				Origin::signed(CHARLIE),
+				origin.clone(),
 				PossibleCollections::APPARTMENTSTEST,
 				ITEM_ID_0,
 				BOB
@@ -165,19 +167,10 @@ fn transfer_works() {
 			Error::<Test>::ItemUnknown
 		);
 
-		// not allowed in Permissions
-		assert_noop!(
-			NFTPallet::transfer(
-				Origin::signed(BOB),
-				PossibleCollections::OFFICESTEST,
-				ITEM_ID_0,
-				DAVE
-			),
-			Error::<Test>::NotPermitted
-		);
-
+		
+		
 		assert_ok!(NFTPallet::transfer(
-			Origin::signed(CHARLIE),
+			origin.clone(),
 			PossibleCollections::HOUSESTEST,
 			ITEM_ID_0,
 			DAVE
@@ -185,7 +178,7 @@ fn transfer_works() {
 		assert_eq!(NFTPallet::owner(HOUSESTEST, ITEM_ID_0).unwrap(), DAVE);
 
 		assert_ok!(NFTPallet::transfer(
-			Origin::signed(EVE),
+			origin.clone(),
 			PossibleCollections::HOUSESTEST,
 			ITEM_ID_0,
 			BOB

--- a/pallets/nft/src/types.rs
+++ b/pallets/nft/src/types.rs
@@ -1,4 +1,5 @@
 pub use super::*;
+use enum_iterator::Sequence;
 pub use frame_support::inherent::Vec;
 use frame_support::pallet_prelude::*;
 #[cfg(feature = "std")]
@@ -8,7 +9,7 @@ pub use scale_info::{prelude::vec, TypeInfo};
 
 /// NFT Collection ID
 pub type CollectionId = u32;
-#[derive(Clone, Encode, Decode, PartialEq, Eq, TypeInfo, Copy)]
+#[derive(Clone, Encode, Decode, PartialEq, Eq, TypeInfo, Copy,Sequence)]
 #[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
 pub enum PossibleCollections {
 	HOUSES,
@@ -32,6 +33,7 @@ impl PossibleCollections {
 			PossibleCollections::NONEXISTING => 3,
 		}
 	}
+
 }
 
 /// NFT Item ID
@@ -54,7 +56,6 @@ pub struct ItemInfo<BoundedVec> {
 pub trait NftPermission<Acc> {
 	fn can_create(created_by: &Acc) -> bool;
 	fn can_mint(created_by: &Acc) -> bool;
-	fn can_transfer(created_by: &Acc) -> bool;
 	fn can_burn(created_by: &Acc) -> bool;
 	fn can_destroy(created_by: &Acc) -> bool;
 	fn has_deposit(created_by: &Acc) -> bool;
@@ -71,10 +72,6 @@ impl NftPermission<Acc> for NftPermissions {
 
 	fn can_mint(created_by: &Acc) -> bool {
 		matches!(*created_by, Acc::SELLER)
-	}
-
-	fn can_transfer(created_by: &Acc) -> bool {
-		matches!(*created_by, Acc::SERVICER)
 	}
 
 	fn can_burn(created_by: &Acc) -> bool {

--- a/pallets/onboarding/src/lib.rs
+++ b/pallets/onboarding/src/lib.rs
@@ -133,7 +133,7 @@ pub mod pallet {
 	#[pallet::storage]
 	#[pallet::getter(fn houses)]
 	/// Stores Asset info
-	pub(super) type Houses<T: Config> = StorageDoubleMap<
+	pub type Houses<T: Config> = StorageDoubleMap<
 		_,
 		Blake2_128Concat,
 		T::NftCollectionId,
@@ -323,64 +323,7 @@ pub mod pallet {
 			Ok(())
 		}
 
-		///Execute the buy/sell transaction
-		#[pallet::weight(10_000 + T::DbWeight::get().reads_writes(1,1))]
-		pub fn do_buy(
-			origin: OriginFor<T>,
-			collection: NftCollectionOf,
-			item_id: T::NftItemId,
-			buyer: T::AccountId,
-			_infos: Asset<T>,
-		) -> DispatchResult {
-			let _caller = ensure_signed(origin.clone()).unwrap();
-			let collection_id: T::NftCollectionId = collection.clone().value().into();
-
-			//Check that the house item exists and has the correct status
-			ensure!(
-				Houses::<T>::contains_key(collection_id.clone(), item_id.clone()),
-				Error::<T>::CollectionOrItemUnknown
-			);
-			let asset = Self::houses(collection_id.clone(), item_id.clone()).unwrap();
-			let status = asset.status;
-			ensure!(status == AssetStatus::FINALISED, Error::<T>::VoteNedeed);
-
-			//Check that the owner is not the buyer
-			let owner = Nft::Pallet::<T>::owner(collection_id.clone(), item_id.clone())
-				.ok_or(Error::<T>::CollectionOrItemUnknown)?;
-			ensure!(buyer != owner.clone(), Error::<T>::BuyFromSelf);
-			let balance = <T as Config>::Currency::reserved_balance(&owner);
-			let _returned = <T as Config>::Currency::unreserve(&owner, balance);
-
-			//Transfer funds from HousingFund to owner
-			let price = Prices::<T>::get(collection_id.clone(), item_id.clone()).unwrap();
-			let fund_id = T::PalletId::get().into_account_truncating();
-			<T as Config>::Currency::transfer(
-				&fund_id,
-				&owner,
-				price,
-				ExistenceRequirement::KeepAlive,
-			)?;
-			let to = T::Lookup::unlookup(buyer.clone());
-			Nft::Pallet::<T>::transfer(origin.clone(), collection, item_id.clone(), to)?;
-			Self::deposit_event(Event::TokenSold {
-				owner,
-				buyer,
-				collection: collection_id.clone(),
-				item: item_id.clone(),
-				price,
-			});
-
-			//change status
-			Self::change_status(
-				origin.clone(),
-				collection.clone(),
-				item_id.clone(),
-				AssetStatus::PURCHASED,
-			)
-			.ok();
-
-			Ok(())
-		}
+		
 
 		#[pallet::weight(10_000 + T::DbWeight::get().reads_writes(1,1))]
 		pub fn reject_edit(

--- a/pallets/share_distributor/Cargo.toml
+++ b/pallets/share_distributor/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/Fair-Squares/fair-squares/"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
+enum-iterator = "1.2.0"
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [
 	"derive",
 ] }

--- a/pallets/share_distributor/src/functions.rs
+++ b/pallets/share_distributor/src/functions.rs
@@ -4,6 +4,7 @@
 //3) Use onboarding do_buy
 //4) transfer tokens to owners
 use super::*;
+use enum_iterator::all;
 
 impl<T: Config> Pallet<T> {
 pub fn virtual_account(collection_id: T::NftCollectionId, item_id: T::NftItemId) -> DispatchResult {
@@ -20,5 +21,23 @@ pub fn virtual_account(collection_id: T::NftCollectionId, item_id: T::NftItemId)
     
 
     Ok(())
+}
+pub fn nft_transaction(collection_id: T::NftCollectionId, item_id: T::NftItemId,virtual_id:T::AccountId) -> DispatchResult {
+    
+    //Get collection
+        let collection_vec = all::<Nft::PossibleCollections>().collect::<Vec<_>>();
+        let _infos = Onboarding::Houses::<T>::get(collection_id.clone(),item_id.clone()).unwrap();
+        let mut coll_id = Nft::PossibleCollections::HOUSES;
+        for i in collection_vec.iter() {
+            let val:T::NftCollectionId=i.value().into();
+            if val == collection_id{
+                coll_id = *i;                
+            }
+        }
+    //Execute NFT and money transfer
+        Onboarding::Pallet::do_buy(coll_id,item_id.clone(),virtual_id.clone(),_infos).ok();        
+
+Ok(())
+
 }
 }

--- a/pallets/share_distributor/src/lib.rs
+++ b/pallets/share_distributor/src/lib.rs
@@ -6,6 +6,7 @@ pub use pallet_assets as Assets;
 pub use pallet_nft as Nft;
 pub use pallet_roles as Roles;
 pub use pallet_onboarding as Onboarding;
+pub use pallet_housing_fund as HousingFund;
 
 mod functions;
 mod types;
@@ -33,7 +34,7 @@ pub mod pallet {
 
 	/// Configure the pallet by specifying the parameters and types on which it depends.
 	#[pallet::config]
-	pub trait Config: frame_system::Config + Assets::Config + Roles::Config + Nft::Config + Onboarding::Config{
+	pub trait Config: frame_system::Config + Assets::Config + Roles::Config + Nft::Config + Onboarding::Config + HousingFund::Config{
 		/// Because this pallet emits events, it depends on the runtime's definition of an event.
 		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
 		type Currency: ReservableCurrency<Self::AccountId>;
@@ -64,7 +65,13 @@ pub mod pallet {
 			account: T::AccountId,
 			collection: T::NftCollectionId,
 			item: T::NftItemId,
+			when: BlockNumberOf<T>
 		},
+		NftTransactionExecuted{
+			nft_transfer_to: T::AccountId,
+			nft_transfer_from: T::AccountId,
+			when: BlockNumberOf<T>
+		}
 	}
 
 
@@ -84,19 +91,32 @@ pub mod pallet {
 		#[pallet::weight(10_000 + T::DbWeight::get().writes(1))]
 		pub fn create_virtual(origin: OriginFor<T>, collection_id: T::NftCollectionId, item_id: T::NftItemId) -> DispatchResult {
 			
-			let _caller = ensure_root(origin);
-			
+			let _caller = ensure_root(origin.clone());
+			let seller: T::AccountId = Nft::Pallet::<T>::owner(collection_id.clone(),item_id.clone()).unwrap();
 
 			// Create virtual account
 			Self::virtual_account(collection_id.clone(),item_id.clone()).ok();
 			let account = Self::virtual_acc(collection_id.clone(),item_id.clone()).unwrap().virtual_account;
 
+			// execute NFT transaction
+			Self::nft_transaction(collection_id.clone(),item_id.clone(),account.clone()).ok();
+
 			// Emit an event.
+			let created = <frame_system::Pallet<T>>::block_number();
 			Self::deposit_event(Event::VirtualCreated{
-				account: account,
-				collection: collection_id,
-				item: item_id,
+				account: account.clone(),
+				collection: collection_id.clone(),
+				item: item_id.clone(),
+				when: created.clone(),
+			});			
+
+			//Emit another event
+			Self::deposit_event(Event::NftTransactionExecuted{
+				nft_transfer_to: account,
+				nft_transfer_from: seller,
+				when: created
 			});
+
 			Ok(())
 		}
 

--- a/pallets/share_distributor/src/types.rs
+++ b/pallets/share_distributor/src/types.rs
@@ -14,7 +14,7 @@ pub use frame_support::{
 pub use frame_system::{ensure_signed, pallet_prelude::*, RawOrigin};
 pub use scale_info::{prelude::{vec,format}, TypeInfo};
 pub use serde::{Deserialize, Serialize};
-
+pub type BlockNumberOf<T> = <T as frame_system::Config>::BlockNumber;
 
 
 #[derive(Clone, Encode, Decode, Default, PartialEq, Eq, TypeInfo)]
@@ -25,6 +25,8 @@ pub struct Ownership<T:Config> {
 	pub virtual_account: T::AccountId,
 	/// NFT owners accounts list
 	pub owners: Vec<T::AccountId>,
+	///Creation Blocknumber
+	pub created: BlockNumberOf<T> 
 }
 
 impl<T: Config> Ownership<T> {
@@ -34,7 +36,8 @@ impl<T: Config> Ownership<T> {
 		virtual_account: T::AccountId
 	) -> DispatchResult {
 		let owners = Vec::new();
-		let ownership = Ownership::<T>{ virtual_account,owners};
+		let created = <frame_system::Pallet<T>>::block_number();
+		let ownership = Ownership::<T>{ virtual_account,owners,created};
 		Virtual::<T>::insert(collection,item,ownership);
 
 		Ok(())		

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -978,7 +978,6 @@ impl Contains<Call> for DontAllowCollectiveAndDemocracy {
 			Call::NftModule(_) => false,
 			Call::OnboardingModule(pallet_onboarding::Call::do_something { .. }) => false,
 			Call::OnboardingModule(pallet_onboarding::Call::change_status { .. }) => false,
-			Call::OnboardingModule(pallet_onboarding::Call::do_buy { .. }) => false,
 			Call::OnboardingModule(pallet_onboarding::Call::reject_edit { .. }) => false,
 			Call::OnboardingModule(pallet_onboarding::Call::reject_destroy { .. }) => false,
 			_ => true,


### PR DESCRIPTION
- `nft_transaction` was added in share_distributor functions.rs
- Event `NftTransactionExecuted` was added
- In `pallet_onboarding`, `do_buy` function was moved to the helpers file (functions.rs)
- `do_buy` origin parameter was removed, as it uses `frame_system::RawOrigin::Root` instead
- The signed orign of the virtual account is used at the end of `do_buy` to change the asset status: this way. no origin is needed in parameter

The `pallet_share_distributor` is connected to `house_fund`, and therefore only needs the `collection_id` & `item_id` from `pallet_bidding`.
the crate `enum_iterator` was also used to iterate through an enum. This could be useful for future commits.