### PR TITLE
Nft metadata modifications

### DIFF
--- a/pallets/onboarding/src/functions.rs
+++ b/pallets/onboarding/src/functions.rs
@@ -57,14 +57,13 @@ impl<T: Config> Pallet<T> {
 		item_id: T::NftItemId,
 		new_price: Option<BalanceOf<T>>,
 	) -> DispatchResult {
-		let sender = ensure_signed(origin)?;
-		let collection_id: T::NftCollectionId = collection.value().into();
+		let sender = ensure_signed(origin.clone())?;
+		let collection_id: T::NftCollectionId = collection.clone().value().into();
 
 		ensure!(
-			pallet_nft::Pallet::<T>::owner(collection_id, item_id) == Some(sender.clone()),
+			pallet_nft::Pallet::<T>::owner(collection_id, item_id.clone()) == Some(sender.clone()),
 			Error::<T>::NotTheTokenOwner
 		);
-
 		Prices::<T>::mutate_exists(collection_id, item_id, |price| *price = new_price);
 
 		Self::deposit_event(Event::TokenPriceUpdated {
@@ -76,6 +75,7 @@ impl<T: Config> Pallet<T> {
 
 		Ok(())
 	}
+
 
 	///Execute the buy/sell transaction
 		

--- a/pallets/onboarding/src/lib.rs
+++ b/pallets/onboarding/src/lib.rs
@@ -591,6 +591,7 @@ pub mod pallet {
 			collection: NftCollectionOf,
 			item_id: T::NftItemId,
 			price: Option<BalanceOf<T>>,
+			data: Option<Nft::BoundedVecOfUnq<T>>,
 		) -> DispatchResult {
 			let caller = ensure_signed(origin.clone()).unwrap();
 			ensure!(Roles::Pallet::<T>::sellers(&caller).is_some(),Error::<T>::ReservedToSeller);
@@ -608,6 +609,15 @@ pub mod pallet {
 
 			//Edit asset price
 			let price0 = Prices::<T>::get(collection_id.clone(), item_id.clone()).unwrap();
+
+			let data0 = Nft::Pallet::<T>::items(collection_id.clone(),item_id.clone()).unwrap().metadata;
+			let data1 = data.unwrap_or(data0.clone());
+			let collection_owner = Nft::Pallet::<T>::collection_owner(collection_id.clone()).unwrap();
+			if data1.clone() !=data0 {
+
+				let res = Nft::Pallet::<T>::set_metadata(collection_owner, collection_id.clone(), item_id.clone(),data1);
+				debug_assert!(res.is_ok());
+			}
 
 			let mut b = price.unwrap_or(price0);
 			if b == Zero::zero() {

--- a/pallets/onboarding/src/tests.rs
+++ b/pallets/onboarding/src/tests.rs
@@ -31,7 +31,7 @@ fn create_proposal() {
 		assert_ok!(NftModule::create_collection(
 			Origin::signed(CHARLIE),
 			NftColl::OFFICESTEST,
-			metadata0
+			metadata0.clone(),
 		));
 		// Bob creates a proposal without submiting for review
 		let price = 100_000_000;
@@ -90,7 +90,8 @@ fn create_proposal() {
 			Origin::signed(BOB),
 			NftColl::OFFICESTEST,
 			item_id,
-			None
+			None,
+			Some(metadata0.clone()),
 		));
 
 		let house_price = Houses::<Test>::get(coll_id.clone(), item_id.clone()).unwrap().price;
@@ -98,6 +99,7 @@ fn create_proposal() {
 		let status: AssetStatus =
 			Houses::<Test>::get(coll_id.clone(), item_id.clone()).unwrap().status;
 		assert_eq!(status, AssetStatus::REVIEWING);
+		assert_eq!(Nft::Pallet::<Test>::items(coll_id.clone(), item_id.clone()).unwrap().metadata,metadata0);
 		
 	});
 }


### PR DESCRIPTION
**Motivations**
In the Onboarding Pallet, the Seller could only modify the price of the asset before submission to the council.
Now he can also change the asset metadata.

**Execution**
- The helper_function `set_metadata(owner: T::AccountId,
		collection_id: T::NftCollectionId,
		item_id: T::NftItemId,
		metadata: BoundedVecOfUnq<T>,
	)`
was added to the nft pallet. This helper function is actually using the `pallet_uniques`  `set_metadata`. 
- In the `pallet_onboarding`, the user can change the initial metadata through the dispatchable function `submit_awaiting(...)`.
- Tests in onboarding were also updated

