### PR TITLE
Added an event to  dispatch

### DIFF
--- a/pallets/onboarding/src/lib.rs
+++ b/pallets/onboarding/src/lib.rs
@@ -212,7 +212,13 @@ pub mod pallet {
 		FundsReserved { from_who: T::AccountId, amount: Option<BalanceOf<T>> },
 		///Funds slashed
 		SlashedFunds { from_who: T::AccountId, amount: Option<BalanceOf<T>> },
+		///StatusChanged
+		AssetStatusChanged {
+			changed_to: AssetStatus,
+			collection: T::NftCollectionId,
+			item: T::NftItemId,
 	}
+}
 
 	// Errors inform users that something went wrong.
 	#[pallet::error]
@@ -278,7 +284,15 @@ pub mod pallet {
 			status: AssetStatus,
 		) -> DispatchResult {
 			let _caller = ensure_signed(origin.clone()).unwrap();
-			Self::status(collection, item_id, status);
+			let coll_id: T::NftCollectionId = collection.clone().value().into();
+			Self::status(collection.clone(), item_id.clone(), status.clone());
+			Self::deposit_event(Event::AssetStatusChanged {
+				changed_to: status,
+				collection: coll_id,
+				item: item_id,
+		});
+
+
 			Ok(())
 		}
 
@@ -474,6 +488,7 @@ pub mod pallet {
 			let house = Self::houses(collection_id.clone(), item_id.clone()).unwrap();
 
 			let _new_call = VotingCalls::<T>::new(collection_id.clone(), item_id.clone()).ok();
+
 			//Create Call for collective-to-democracy status change
 			let call1: T::Prop = Call::<T>::change_status {
 				collection: collection.clone(),

--- a/pallets/roles/src/lib.rs
+++ b/pallets/roles/src/lib.rs
@@ -299,7 +299,7 @@ pub mod pallet {
 				sender == SUDO::Pallet::<T>::key().unwrap(),
 				"only the current sudo key can sudo"
 			);
-			ensure!(sender != new0, "The same manager is given");
+			//ensure!(sender != new0, "The same manager is given");
 			//Remove current Sudo from Servicers list
 			if ServicerLog::<T>::contains_key(sender.clone()) == true {
 				ServicerLog::<T>::remove(sender.clone());


### PR DESCRIPTION
- In `pallet_roles/set_manager` dispatch, do not check that new and old manager are different accounts
- Ads an event to the `pallet_onboarding/change_status` dispatch function

**Motivation**
- Pallet roles
1. The sudo pallet_key cannot be attributed to more than one account
2. By Default, Alice has the sudo_key, but has no role.
The sudo key should have the authority to attribute a role to himself. the `set_role` dispatch will only work if no role is attributed yet. The check implemented previously only prevent the sudo key to get a role during the Genesis stage of the pallet

- Pallet Onboarding
An event makes it easier to track the status change, and see clearly if the corresponding calls are executed or not.


