### PR TITLE
Added a storage to track owners and their shares

### DIFF
--- a/pallets/share_distributor/src/lib.rs
+++ b/pallets/share_distributor/src/lib.rs
@@ -84,6 +84,17 @@ pub mod pallet {
 		Ownership<T>,
 		OptionQuery,
 	>;
+
+	#[pallet::storage]
+	#[pallet::getter(fn tokens_infos)]
+	/// Stores Tokens infos
+	pub type Tokens<T: Config> = StorageMap<
+		_,
+		Blake2_128Concat,
+		T::AccountId,		
+		Owners<T>,
+		OptionQuery,
+	>;
 	
 	#[pallet::type_value]
 	///Initializing Token id to value 0
@@ -116,6 +127,7 @@ pub mod pallet {
 			from: T::AccountId,
 			to: Vec<T::AccountId>,
 			token_id:<T as pallet::Config>::AssetId,
+			owners:Vec<(T::AccountId,<T as Assets::Config>::Balance)>,
 		}
 
 	}
@@ -175,10 +187,12 @@ pub mod pallet {
 
 			let new_owners = Self::virtual_acc(collection_id.clone(),item_id.clone()).unwrap().owners;
 			let token_id = Self::virtual_acc(collection_id.clone(),item_id.clone()).unwrap().token_id;
+			let owners = Self::tokens_infos(account.clone()).unwrap().owners;
 			Self::deposit_event(Event::OwnershipTokensDistributed{
 				from: account.clone(),
 				to: new_owners,
-				token_id: token_id,
+				token_id,
+				owners,
 			});
 
 			Ok(())

--- a/pallets/share_distributor/src/tests.rs
+++ b/pallets/share_distributor/src/tests.rs
@@ -252,6 +252,19 @@ fn share_distributor1(){
 		let when = <frame_system::Pallet<Test>>::block_number();
 		let new_owner0 = ShareDistributor::virtual_acc(coll_id0.clone(),item_id0.clone()).unwrap().virtual_account;
 		let owners = ShareDistributor::virtual_acc(coll_id0.clone(),item_id0.clone()).unwrap().owners;
+		let id = ShareDistributor::virtual_acc(coll_id0.clone(),item_id0.clone()).unwrap().token_id;
+		println!("The token id is:{:?}",id.clone());
+		assert_eq!(100,Assets::Pallet::<Test>::total_supply(id.clone()));
+
+		let balance0 = Assets::Pallet::<Test>::balance(id.clone(),DAVE);
+		let balance1 = Assets::Pallet::<Test>::balance(id.clone(),EVE);
+		let balance2 = Assets::Pallet::<Test>::balance(id.clone(),new_owner0.clone());
+		
+		println!("Tokens own by DAVE:{:?}\nTokens own by Eve:{:?}\nTokens own by Virtual_account:{:?}",balance0,balance1,balance2);
+		let infos = ShareDistributor::tokens_infos(new_owner0.clone()).unwrap().owners;
+
+		println!("Again, new owners are:\n{:?}",infos);
+
 		assert_eq!(owners.len()>1,true);
 		expect_events(vec![
 			crate::Event::VirtualCreated {

--- a/pallets/share_distributor/src/types.rs
+++ b/pallets/share_distributor/src/types.rs
@@ -19,6 +19,38 @@ pub type BalanceOf<T> =
 	<<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
 
 
+	#[derive(Clone, Encode, Decode, PartialEq, Eq, TypeInfo)]
+	#[scale_info(skip_type_params(T))]
+	#[cfg_attr(feature = "std", derive(Debug))]
+	pub struct Owners<T:Config> {
+		
+		pub owners: Vec<(T::AccountId,<T as Assets::Config>::Balance)>,
+		///Creation Blocknumber
+		pub created: BlockNumberOf<T>,
+		///TokenId
+		pub token_id: <T as pallet::Config>::AssetId,
+		///Total supply of tokens
+		pub supply: <T as Assets::Config>::Balance
+	}
+
+	impl<T: Config> Owners<T> {
+		pub fn new(			
+			virtual_account: T::AccountId
+		) -> DispatchResult {
+			let owners = Vec::new();			
+			let created = <frame_system::Pallet<T>>::block_number();
+			let token_id:<T as pallet::Config>::AssetId = TokenId::<T>::get().into();
+			let supply = Zero::zero();
+			let tokens = Owners::<T>{owners,created,token_id,supply};
+
+					
+			Tokens::<T>::insert(virtual_account,tokens);
+	
+			Ok(())		
+		}
+	}
+
+
 #[derive(Clone, Encode, Decode, PartialEq, Eq, TypeInfo)]
 #[scale_info(skip_type_params(T))]
 #[cfg_attr(feature = "std", derive(Debug))]


### PR DESCRIPTION
Added a new storage 
`Tokens<T: Config> = StorageMap<		_,
		Blake2_128Concat,
		T::AccountId,		
		Owners<T>,
		OptionQuery,
	>;`
it uses the virtual account to retrieve the struct `Owners`.
this struct contains the following fields:
`pub struct Owners<T:Config> {
		
		pub owners: Vec<(T::AccountId,<T as Assets::Config>::Balance)>,
		///Creation Blocknumber
		pub created: BlockNumberOf<T>,
		///TokenId
		pub token_id: <T as pallet::Config>::AssetId,
		///Total supply of tokens
		pub supply: <T as Assets::Config>::Balance
	}`
All related functions and tests have been updated.
