### PR TITLE
212 representative vote blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4046,6 +4046,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.29)",
 ]
 
 [[package]]

--- a/pallets/asset_management/Cargo.toml
+++ b/pallets/asset_management/Cargo.toml
@@ -16,6 +16,9 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [
 	"derive",
 ] }
+sp-std = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
+sp-core = { version = "6.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.29" }
+sp-runtime = { version = "6.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.29" }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, optional = true, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.29" }
 frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.29" }
@@ -38,12 +41,16 @@ pallet-assets = { git = "https://github.com/paritytech/substrate", branch = "pol
 sp-core = { version = "6.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.29" }
 sp-io = { version = "6.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.29" }
 sp-runtime = { version = "6.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.29" }
+sp-std = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
 
 
 [features]
 default = ["std"]
 std = [
 	"codec/std",
+	"sp-std/std",
+	"sp-core/std",
+	"sp-runtime/std",
 	"frame-benchmarking/std",
 	"frame-support/std",
 	"frame-system/std",

--- a/pallets/asset_management/src/functions.rs
+++ b/pallets/asset_management/src/functions.rs
@@ -1,9 +1,10 @@
 //Helper functions that will be used in proposal's calls
 //helper 1) get shares/owners from asset_id  
 pub use super::*;
-
+pub use scale_info::prelude::boxed::Box;
 
 pub use frame_support::pallet_prelude::*;
+pub use sp_core::H256;
 impl<T: Config> Pallet<T> {
     pub fn approve_representative(caller: T::AccountId, who:T::AccountId) -> DispatchResult{
         let mut representative = Roles::Pallet::<T>::get_pending_representatives(&who).unwrap();
@@ -16,7 +17,7 @@ impl<T: Config> Pallet<T> {
         Ok(())
     }
 
-    pub fn create_proposal_hash_and_note(caller: T::AccountId,call:<T as pallet::Config>::Call) -> Vec<u8> {
+    pub fn create_proposal_hash_and_note(caller: T::AccountId,call:<T as pallet::Config>::Call) -> T::Hash {
         let origin = RawOrigin::Signed(caller);
         let call_wrap = Box::new(call);
         let proposal_hash = T::Hashing::hash_of(&call_wrap);
@@ -26,7 +27,7 @@ impl<T: Config> Pallet<T> {
             Err(x) if x == Error::<T>::DuplicatePreimage.into() => (),
             Err(x) => panic!("{:?}", x),
         }
-        proposal_encoded
+        proposal_hash
     }
     
 }

--- a/pallets/asset_management/src/functions.rs
+++ b/pallets/asset_management/src/functions.rs
@@ -2,6 +2,7 @@
 //helper 1) get shares/owners from asset_id  
 pub use super::*;
 
+
 pub use frame_support::pallet_prelude::*;
 impl<T: Config> Pallet<T> {
     pub fn approve_representative(caller: T::AccountId, who:T::AccountId) -> DispatchResult{
@@ -13,6 +14,19 @@ impl<T: Config> Pallet<T> {
         Roles::AccountsRolesLog::<T>::insert(&who, Roles::Accounts::REPRESENTATIVE);
 
         Ok(())
+    }
+
+    pub fn create_proposal_hash_and_note(caller: T::AccountId,call:<T as pallet::Config>::Call) -> Vec<u8> {
+        let origin = RawOrigin::Signed(caller);
+        let call_wrap = Box::new(call);
+        let proposal_hash = T::Hashing::hash_of(&call_wrap);
+        let proposal_encoded: Vec<u8> = proposal_hash.encode();
+        match Dem::Pallet::<T>::note_preimage(origin.into(), proposal_encoded.clone()) {
+            Ok(_) => (),
+            Err(x) if x == Error::<T>::DuplicatePreimage.into() => (),
+            Err(x) => panic!("{:?}", x),
+        }
+        proposal_encoded
     }
     
 }

--- a/pallets/asset_management/src/lib.rs
+++ b/pallets/asset_management/src/lib.rs
@@ -18,6 +18,7 @@ pub use pallet_housing_fund as HFund;
 mod functions;
 mod types;
 pub use crate::types::*;
+pub use functions::*;
 
 #[cfg(test)]
 mod mock;
@@ -42,17 +43,30 @@ pub mod pallet {
 	pub trait Config: frame_system::Config + HFund::Config + Onboarding::Config +Roles::Config + Dem::Config + Share::Config + Nft::Config{
 		/// Because this pallet emits events, it depends on the runtime's definition of an event.
 		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
+		type Call: Parameter
+			+ UnfilteredDispatchable<Origin = <Self as frame_system::Config>::Origin>
+			+ From<Call<Self>>
+			+ GetDispatchInfo;
+		type Delay: Get<Self::BlockNumber>;
+		type CheckDelay: Get<Self::BlockNumber>;
+		type InvestorVoteAmount: Get<u128>;
 		type Currency: Currency<Self::AccountId> + ReservableCurrency<Self::AccountId>;
 		type WeightInfo: WeightInfo;
+
+		#[pallet::constant]
+		type MinimumDepositVote: Get<BalanceOf<Self>>;
+
+		#[pallet::constant]
+		type CheckPeriod: Get<Self::BlockNumber>;
 	}
 
-	// The pallet's runtime storage items.
-	// https://docs.substrate.io/main-docs/build/runtime-storage/
 	#[pallet::storage]
-	#[pallet::getter(fn something)]
-	// Learn more about declaring storage items:
-	// https://docs.substrate.io/main-docs/build/runtime-storage/#declaring-storage-items
-	pub type Something<T> = StorageValue<_, u32>;
+	#[pallet::getter(fn democracy_proposals)]
+	pub type DemocracyProposals<T: Config> =
+		StorageMap<_, Blake2_128Concat, T::Hash, BlockNumberOf<T>, OptionQuery>;
+
+
+	
 
 	// Pallets use events to inform users when important changes are made.
 	// https://docs.substrate.io/main-docs/build/events-errors/
@@ -73,6 +87,12 @@ pub mod pallet {
 		NotAnAssetAccount,
 		/// Errors should have helpful documentation associated with them.
 		StorageOverflow,
+		///The proposal could not be created
+		FailedToCreateProposal,
+		///This Preimage already exists
+		DuplicatePreimage,
+		///Not an owner in the corresponding virtual account
+		NotAnOwner,
 	}
 
 	// Dispatchable functions allows users to interact with the pallet and invoke state changes.
@@ -80,53 +100,44 @@ pub mod pallet {
 	// Dispatchable functions must be annotated with a weight and must return a DispatchResult.
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
-		/// An example dispatchable that takes a singles value as a parameter, writes the value to
-		/// storage and emits an event. This function must be dispatched by a signed extrinsic.
-		#[pallet::weight(10_000 + T::DbWeight::get().writes(1).ref_time())]
-		pub fn do_something(origin: OriginFor<T>, something: u32) -> DispatchResult {
-			// Check that the extrinsic was signed and get the signer.
-			// This function will return an error if the extrinsic is not signed.
-			// https://docs.substrate.io/main-docs/build/origins/
-			let who = ensure_signed(origin)?;
-
-			// Update storage.
-			<Something<T>>::put(something);
-
-			// Emit an event.
-			Self::deposit_event(Event::SomethingStored(something, who));
-			// Return a successful DispatchResultWithPostInfo
-			Ok(())
-		}
-
-		/// An example dispatchable that may throw a custom error.
+		
+		///Owners Voting system
+		///One owner trigger a vote session with a proposal
 		#[pallet::weight(10_000 + T::DbWeight::get().reads_writes(1,1).ref_time())]
-		pub fn cause_error(origin: OriginFor<T>) -> DispatchResult {
-			let _who = ensure_signed(origin)?;
+		pub fn representative_vote(origin:OriginFor<T>,virtual_account: T::AccountId) -> DispatchResult{
+			let caller = ensure_signed(origin)?;
+			//Ensure that the caller is an owner related to the virtual account
 
-			// Read a value from storage.
-			match <Something<T>>::get() {
-				// Return an error if the value has not been set.
-				None => Err(Error::<T>::NoneValue.into()),
-				Some(old) => {
-					// Increment the value read from storage; will error in the event of overflow.
-					let new = old.checked_add(1).ok_or(Error::<T>::StorageOverflow)?;
-					// Update the value in storage with the incremented result.
-					<Something<T>>::put(new);
-					Ok(())
-				},
-			}
+			//Make proposal
+			let deposit = T::MinimumDeposit::get();
+			//Get NFT infos from virtual_account
+
+			//Create the call 
+			//let rep_call = Call::<T>::representative_approval {
+			//	rep_account:
+			//	collection:
+			//	item:
+			//};
+			//ensure!(rep_call.is_some(),Error::<T>::FailedToCreateProposal);
+
+			//Create the proposal hash
+			//let prop_hash = Self::create_proposal_hash_and_note(caller,rep_call);
+
+
+			
+			Ok(())
 		}
 
 		/// approve a Representative role request
 		#[pallet::weight(10_000 + T::DbWeight::get().reads_writes(1,1).ref_time())]
-		pub fn representative_approval(origin: OriginFor<T>, account: T::AccountId,collection: T::NftCollectionId,item: T::NftItemId) -> DispatchResult {
+		pub fn representative_approval(origin: OriginFor<T>, rep_account: T::AccountId,collection: T::NftCollectionId,item: T::NftItemId) -> DispatchResult {
 			let caller = ensure_signed(origin)?;
 			//Check that the caller is a stored virtual account
 			ensure!(caller == Share::Pallet::<T>::virtual_acc(collection,item).unwrap().virtual_account, Error::<T>::NotAnAssetAccount);
 			//Check that the account is in the representative waiting list
-			ensure!(Roles::Pallet::<T>::get_pending_representatives(&account).is_some(),"problem");
+			ensure!(Roles::Pallet::<T>::get_pending_representatives(&rep_account).is_some(),"problem");
 			//Approve role request
-			Self::approve_representative(caller,account).ok();
+			Self::approve_representative(caller,rep_account).ok();
 
 			Ok(())
 		}

--- a/pallets/asset_management/src/lib.rs
+++ b/pallets/asset_management/src/lib.rs
@@ -59,21 +59,14 @@ pub mod pallet {
 	#[pallet::storage]
 	#[pallet::getter(fn proposals)]
 	pub type ProposalsLog<T: Config> =
-		StorageMap<_, Blake2_128Concat, Dem::ReferendumIndex, RepVote<T>, OptionQuery>;
-
-
-	
+		StorageMap<_, Blake2_128Concat, Dem::ReferendumIndex, RepVote<T>, OptionQuery>;	
 
 	// Pallets use events to inform users when important changes are made.
 	// https://docs.substrate.io/main-docs/build/events-errors/
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event<T: Config> {
-		/// Event documentation should end with an array that provides descriptive names for event
-		/// parameters. [something, who]
-		SomethingStored(u32, T::AccountId),
-
-		///A vote session to elect a representative has started
+		///A voting session to elect a representative has started
 		RepresentativeVoteSessionStarted{
 			caller: T::AccountId,
 			candidate: T::AccountId,

--- a/pallets/asset_management/src/mock.rs
+++ b/pallets/asset_management/src/mock.rs
@@ -327,8 +327,15 @@ impl pallet_housing_fund::Config for Test {
 	type MaxInvestorPerHouse = MaxInvestorPerHouse;
 }
 
+
 impl pallet_asset_management::Config for Test {
 	type Event = Event;
+	type Call = Call;
+	type Delay = Delay;
+	type CheckDelay = CheckDelay;
+	type InvestorVoteAmount = InvestorVoteAmount;
+	type CheckPeriod = CheckPeriod;
+	type MinimumDepositVote = MinimumDeposit;
 	type Currency = Balances;
 	type WeightInfo = ();
 }
@@ -338,7 +345,7 @@ pub const BOB: AccountId = AccountId::new([2u8; 32]);
 pub const CHARLIE: AccountId = AccountId::new([3u8; 32]);
 pub const DAVE: AccountId = AccountId::new([6u8; 32]);
 pub const EVE: AccountId = AccountId::new([5u8; 32]);
-pub const ACCOUNT_WITH_NO_BALANCE0: AccountId = AccountId::new([4u8; 32]);
+//pub const ACCOUNT_WITH_NO_BALANCE0: AccountId = AccountId::new([4u8; 32]);
 pub const FERDIE: AccountId = AccountId::new([7u8; 32]);
 pub const GERARD: AccountId = AccountId::new([8u8; 32]);
 

--- a/pallets/asset_management/src/types.rs
+++ b/pallets/asset_management/src/types.rs
@@ -4,18 +4,24 @@ pub use frame_support::{
 	dispatch::{DispatchResult, EncodeLike},
 	inherent::Vec,
 	pallet_prelude::*,
+    weights::GetDispatchInfo,
 	sp_runtime::{
 		traits::{AccountIdConversion, Hash, One, Saturating, StaticLookup, Zero},
 		PerThing, Percent,
 	},
 	storage::child,
 	traits::{
-		Currency, ExistenceRequirement, Get, LockableCurrency, ReservableCurrency, WithdrawReasons,
+		UnfilteredDispatchable,Currency, ExistenceRequirement, Get, LockableCurrency, ReservableCurrency, WithdrawReasons,
 	},
 	PalletId,
 };
 pub use frame_system::{ensure_signed, pallet_prelude::*, RawOrigin};
 pub use scale_info::{prelude::vec, TypeInfo};
+pub use sp_std::boxed::Box;
+pub use sp_runtime::{
+	traits::{BadOrigin, BlakeTwo256, IdentityLookup},
+	Perbill,
+};
 
 pub type BalanceOf<T> =
 	<<T as pallet::Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;

--- a/pallets/asset_management/src/types.rs
+++ b/pallets/asset_management/src/types.rs
@@ -27,3 +27,44 @@ pub type BalanceOf<T> =
 	<<T as pallet::Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
 pub type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
 pub type BlockNumberOf<T> = <T as frame_system::Config>::BlockNumber;
+
+#[derive(Clone, Encode, Decode, PartialEq, Eq, TypeInfo, Copy)]
+#[cfg_attr(feature = "std", derive(Debug))]
+pub enum VoteResult {
+	AWAITING,
+	ACCEPTED,
+	REJECTED,
+}
+
+#[derive(Clone, Encode, Decode, PartialEq, Eq, TypeInfo)]
+#[scale_info(skip_type_params(T))]
+#[cfg_attr(feature = "std", derive(Debug))]
+pub struct RepVote<T: Config> {
+	///Asset owner who made the proposal
+	pub caller_account: T::AccountId,
+	///Virtual account corresponding to the asset
+	pub virtual_account: T::AccountId,
+	///Candidate for the representative role
+	pub candidate_account: T::AccountId,
+	///Vote result
+	pub vote_result: VoteResult,
+	///Session creation block 
+	pub when: BlockNumberOf<T>,
+	
+}
+
+impl<T: Config> RepVote<T> {
+	pub fn new(
+		caller_account: T::AccountId,
+		virtual_account: T::AccountId,
+		candidate_account: T::AccountId,
+		referendum_index: Dem::ReferendumIndex,	
+	) -> DispatchResult {
+		let vote_result = VoteResult::AWAITING;
+		let when = <frame_system::Pallet<T>>::block_number();
+		let session = RepVote::<T>{caller_account,virtual_account,candidate_account,vote_result,when};
+		ProposalsLog::<T>::insert(referendum_index,session);
+		Ok(())
+		
+	}
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -618,9 +618,16 @@ impl pallet_bidding::Config for Runtime {
 	type MinimumSharePerInvestor = MinimumSharePerInvestor;
 	type NewAssetScanPeriod = NewAssetScanPeriod;
 }
+
 impl pallet_asset_management::Config for Runtime {
 	type Event = Event;
+	type Call = Call;
+	type Delay = Delay;
+	type CheckDelay = CheckDelay;
+	type InvestorVoteAmount = InvestorVoteAmount;
+	type CheckPeriod = CheckPeriod;
 	type Currency = Balances;
+	type MinimumDepositVote = MinimumDeposit;
 	type WeightInfo = ();
 }
 


### PR DESCRIPTION
In order to implement the representative vote the following steps are necessary:

- [x] The call that will be executed after a positive vote
- [x] The function that will create the proposal hash that will be used by the democracy pallet
- [x] The vote session creation by one on the owners
### Next steps:
- Representative referendum extrinsic testing
- Customised voting extrinsic with a fixed balance, equal to the asset share of the owner. (See if we can use the asset token directly...) 