### PR TITLE
Payment pallet tests

### DIFF
--- a/pallets/payment/src/tests.rs
+++ b/pallets/payment/src/tests.rs
@@ -363,3 +363,114 @@ fn test_charging_fee_payment_works() {
 		);
 	});
 }
+
+#[test]
+fn test_charging_fee_payment_works_when_canceled() {
+	new_test_ext().execute_with(|| {
+		let creator_initial_balance = 100_000_000_000;
+		let payment_amount = 40;
+		let expected_incentive_amount = payment_amount / INCENTIVE_PERCENTAGE as u64;
+		let expected_fee_amount = payment_amount / MARKETPLACE_FEE_PERCENTAGE as u64;
+
+		// should be able to create a payment with available balance
+		assert_ok!(PaymentModule::pay(
+			Origin::signed(PAYMENT_CREATOR),
+			PAYMENT_RECIPENT_FEE_CHARGED,
+			payment_amount,
+			None
+		));
+		assert_eq!(
+			PaymentStore::<Test>::get(PAYMENT_CREATOR, PAYMENT_RECIPENT_FEE_CHARGED),
+			Some(PaymentDetail {
+				amount: payment_amount,
+				incentive_amount: expected_incentive_amount,
+				state: PaymentState::Created,
+				resolver_account: RESOLVER_ACCOUNT,
+				fee_detail: Some((FEE_RECIPIENT_ACCOUNT, expected_fee_amount)),
+			})
+		);
+		// the payment amount should be reserved
+		assert_eq!(
+			Balances::free_balance(&PAYMENT_CREATOR),
+			creator_initial_balance - payment_amount - expected_fee_amount - expected_incentive_amount
+		);
+		assert_eq!(Balances::free_balance(&PAYMENT_RECIPENT_FEE_CHARGED), 1);
+
+		// should succeed for valid payment
+		assert_ok!(PaymentModule::cancel(
+			Origin::signed(PAYMENT_RECIPENT_FEE_CHARGED),
+			PAYMENT_CREATOR
+		));
+		// the payment amount should be transferred
+		assert_eq!(
+			Balances::free_balance(&PAYMENT_CREATOR),
+			creator_initial_balance
+		);
+		assert_eq!(Balances::free_balance(&PAYMENT_CREATOR).saturating_add(Balances::reserved_balance(&PAYMENT_CREATOR)), 100_000_000_000);
+		assert_eq!(Balances::free_balance(&PAYMENT_RECIPENT_FEE_CHARGED), 1);
+		assert_eq!(Balances::free_balance(&FEE_RECIPIENT_ACCOUNT), 1);
+	});
+}
+
+
+#[test]
+fn test_pay_with_remark_works() {
+	new_test_ext().execute_with(|| {
+		let creator_initial_balance = 100_000_000_000;
+		let payment_amount = 40;
+		let expected_incentive_amount = payment_amount / INCENTIVE_PERCENTAGE as u64;
+
+		// should be able to create a payment with available balance
+		assert_ok!(PaymentModule::pay(
+			Origin::signed(PAYMENT_CREATOR),
+			PAYMENT_RECIPENT,
+			payment_amount,
+			Some(vec![1u8; 10].try_into().unwrap())
+		));
+		assert_eq!(
+			PaymentStore::<Test>::get(PAYMENT_CREATOR, PAYMENT_RECIPENT),
+			Some(PaymentDetail {
+				amount: payment_amount,
+				incentive_amount: expected_incentive_amount,
+				state: PaymentState::Created,
+				resolver_account: RESOLVER_ACCOUNT,
+				fee_detail: Some((FEE_RECIPIENT_ACCOUNT, 0)),
+			})
+		);
+		// the payment amount should be reserved correctly
+		// the amount + incentive should be removed from the sender account
+		assert_eq!(
+			Balances::free_balance(&PAYMENT_CREATOR),
+			creator_initial_balance - payment_amount - expected_incentive_amount
+		);
+		// the incentive amount should be reserved in the sender account
+		assert_eq!(
+			Balances::free_balance(&PAYMENT_CREATOR).saturating_add(Balances::reserved_balance(&PAYMENT_CREATOR)),
+			creator_initial_balance - payment_amount
+		);
+		assert_eq!(Balances::free_balance(&PAYMENT_RECIPENT), 1);
+		// the transferred amount should be reserved in the recipent account
+		assert_eq!(Balances::free_balance(&PAYMENT_RECIPENT).saturating_add(Balances::reserved_balance(&PAYMENT_RECIPENT)), Balances::free_balance(&PAYMENT_RECIPENT).saturating_add(payment_amount));
+
+		// the payment should not be overwritten
+		assert_noop!(
+			PaymentModule::pay(
+				Origin::signed(PAYMENT_CREATOR),
+				PAYMENT_RECIPENT,
+				payment_amount,
+				None
+			),
+			crate::Error::<Test>::PaymentAlreadyInProcess
+		);
+
+		assert_eq!(
+			last_event(),
+			crate::Event::<Test>::PaymentCreated {
+				from: PAYMENT_CREATOR,
+				amount: payment_amount,
+				remark: Some(vec![1u8; 10].try_into().unwrap())
+			}
+			.into()
+		);
+	});
+}


### PR DESCRIPTION
Adding tests to the payment pallet.
One more round of tests is necessary.