### PR TITLE
Updating storage RequestedRole when creating roles Seller,Servicer,etc ...

### DIFF
--- a/pallets/asset_management/src/functions.rs
+++ b/pallets/asset_management/src/functions.rs
@@ -118,6 +118,18 @@ impl<T: Config> Pallet<T> {
 		infos
 	}
 
+	pub fn vote_helper(share: u128, vote:bool) -> Option<Dem::Vote>{
+
+		match share{
+			50..=100  => Some(Dem::Vote { aye: vote, conviction: Dem::Conviction::Locked1x }),
+			101..=150 => Some(Dem::Vote { aye: vote, conviction: Dem::Conviction::Locked2x }),
+			151..=300 => Some(Dem::Vote { aye: vote, conviction: Dem::Conviction::Locked3x }),
+			301..=350 => Some(Dem::Vote { aye: vote, conviction: Dem::Conviction::Locked4x }),
+			351..=400 => Some(Dem::Vote { aye: vote, conviction: Dem::Conviction::Locked4x }),
+			_ => None,
+		}
+	}
+
 	pub fn tenant_link_asset(
 		tenant: T::AccountId,
 		collection: T::NftCollectionId,

--- a/pallets/asset_management/src/functions.rs
+++ b/pallets/asset_management/src/functions.rs
@@ -118,14 +118,14 @@ impl<T: Config> Pallet<T> {
 		infos
 	}
 
-	pub fn vote_helper(share: u128, vote:bool) -> Option<Dem::Vote>{
-
-		match share{
-			50..=100  => Some(Dem::Vote { aye: vote, conviction: Dem::Conviction::Locked1x }),
+	pub fn vote_helper(share: u128, vote: bool) -> Option<Dem::Vote> {
+		match share {
+			50..=100 => Some(Dem::Vote { aye: vote, conviction: Dem::Conviction::Locked1x }),
 			101..=150 => Some(Dem::Vote { aye: vote, conviction: Dem::Conviction::Locked2x }),
 			151..=300 => Some(Dem::Vote { aye: vote, conviction: Dem::Conviction::Locked3x }),
 			301..=350 => Some(Dem::Vote { aye: vote, conviction: Dem::Conviction::Locked4x }),
-			351..=400 => Some(Dem::Vote { aye: vote, conviction: Dem::Conviction::Locked4x }),
+			351..=400 => Some(Dem::Vote { aye: vote, conviction: Dem::Conviction::Locked5x }),
+			401.. => Some(Dem::Vote { aye: vote, conviction: Dem::Conviction::Locked6x }),
 			_ => None,
 		}
 	}
@@ -349,14 +349,13 @@ impl<T: Config> Pallet<T> {
 						//Reserve maintenance fees
 						let reservation =
 							<T as Config>::Currency::reserve(&asset_account, maintenance.into());
-						
-							//Emmit maintenance fee payment event
+
+						//Emmit maintenance fee payment event
 						Self::deposit_event(Event::MaintenanceFeesPayment {
 							tenant: tenant.account_id.clone(),
 							when: now,
 							asset_account: tenant.asset_account.unwrap(),
 							amount: maintenance.clone(),
-							
 						});
 
 						debug_assert!(reservation.is_ok());

--- a/pallets/asset_management/src/functions.rs
+++ b/pallets/asset_management/src/functions.rs
@@ -300,7 +300,7 @@ impl<T: Config> Pallet<T> {
 
 					//check how many rents were payed
 					let payed = (time as u128 - remaining_p as u128) * rent.clone();
-					let asset_account = tenant.asset_account.unwrap();
+					let asset_account = tenant.asset_account.clone().unwrap();
 					let asset_account_free_balance =
 						<T as Config>::Currency::free_balance(&asset_account);
 
@@ -337,6 +337,15 @@ impl<T: Config> Pallet<T> {
 						//Reserve maintenance fees
 						let reservation =
 							<T as Config>::Currency::reserve(&asset_account, maintenance.into());
+						
+							//Emmit maintenance fee payment event
+						Self::deposit_event(Event::MaintenanceFeesPayment {
+							tenant: tenant.account_id.clone(),
+							when: now,
+							asset_account: tenant.asset_account.unwrap(),
+							amount: maintenance.clone(),
+							
+						});
 
 						debug_assert!(reservation.is_ok());
 

--- a/pallets/asset_management/src/lib.rs
+++ b/pallets/asset_management/src/lib.rs
@@ -228,6 +228,15 @@ pub mod pallet {
 			amount: Payment::BalanceOf<T>,
 			when: BlockNumberOf<T>,
 		},
+
+			//Asset maintenance fees, have been taken from the rent received, and reserved 
+			MaintenanceFeesPayment
+			{
+				tenant: T::AccountId,
+				when: BlockNumberOf<T>,
+				asset_account: T::AccountId,
+				amount: BalanceOf<T>,
+			},
 	}
 
 	// Errors inform users that something went wrong.

--- a/pallets/asset_management/src/lib.rs
+++ b/pallets/asset_management/src/lib.rs
@@ -537,15 +537,12 @@ pub mod pallet {
 			let rep = rep.unwrap();
 			ensure!(rep.activated, Error::<T>::NotAnActiveRepresentative);
 
-			// Ensure that the tenant is registered
-			let tenant_infos = Roles::Pallet::<T>::tenants(tenant.clone()).unwrap();
-			ensure!(tenant_infos.registered == true, Error::<T>::NotARegisteredTenant);
-
 			// Get the asset virtual account if exists
 			let collection_id: T::NftCollectionId = asset_type.value().into();
 			let ownership = Share::Pallet::<T>::virtual_acc(collection_id, asset_id);
 			ensure!(ownership.is_some(), Error::<T>::NotAnAsset);
 
+			
 			//Compare guaranty payment amount+fees with tenant free_balance
 			let guaranty = Self::calculate_guaranty(collection_id, asset_id);
 			let fee0 = Self::manage_bal_to_u128(T::RepFees::get()).unwrap();
@@ -561,6 +558,9 @@ pub mod pallet {
 			// Ensure that provided account is a valid tenant
 			let tenant0 = Roles::Pallet::<T>::tenants(tenant.clone());
 			ensure!(tenant0.is_some(), Error::<T>::NotATenant);
+			// Ensure that the tenant is registered
+			let tenant_infos = Roles::Pallet::<T>::tenants(tenant.clone()).unwrap();
+			ensure!(tenant_infos.registered == true, Error::<T>::NotARegisteredTenant);
 
 			let tenant0 = tenant0.unwrap();
 			match proposal {

--- a/pallets/asset_management/src/lib.rs
+++ b/pallets/asset_management/src/lib.rs
@@ -269,6 +269,8 @@ pub mod pallet {
 		ExistingPaymentRequest,
 		/// Not enough funds in the tenant account
 		NotEnoughTenantFunds,
+		/// The Tenant did not provide detailed information
+		NotARegisteredTenant,
 	}
 
 	#[pallet::hooks]
@@ -534,6 +536,10 @@ pub mod pallet {
 			ensure!(rep.is_some(), Error::<T>::NotARepresentative);
 			let rep = rep.unwrap();
 			ensure!(rep.activated, Error::<T>::NotAnActiveRepresentative);
+
+			// Ensure that the tenant is registered
+			let tenant_infos = Roles::Pallet::<T>::tenants(tenant.clone()).unwrap();
+			ensure!(tenant_infos.registered == true, Error::<T>::NotARegisteredTenant);
 
 			// Get the asset virtual account if exists
 			let collection_id: T::NftCollectionId = asset_type.value().into();

--- a/pallets/asset_management/src/lib.rs
+++ b/pallets/asset_management/src/lib.rs
@@ -229,14 +229,13 @@ pub mod pallet {
 			when: BlockNumberOf<T>,
 		},
 
-			//Asset maintenance fees, have been taken from the rent received, and reserved 
-			MaintenanceFeesPayment
-			{
-				tenant: T::AccountId,
-				when: BlockNumberOf<T>,
-				asset_account: T::AccountId,
-				amount: BalanceOf<T>,
-			},
+		//Asset maintenance fees, have been taken from the rent received, and reserved
+		MaintenanceFeesPayment {
+			tenant: T::AccountId,
+			when: BlockNumberOf<T>,
+			asset_account: T::AccountId,
+			amount: BalanceOf<T>,
+		},
 	}
 
 	// Errors inform users that something went wrong.
@@ -440,7 +439,7 @@ pub mod pallet {
 			let token1 = bals0.dem_bal;
 
 			//let v = Dem::Vote { aye: vote, conviction: Dem::Conviction::Locked1x };
-			let v = Self::vote_helper(token0,vote).unwrap();
+			let v = Self::vote_helper(token0, vote).unwrap();
 			Dem::Pallet::<T>::vote(
 				origin.clone(),
 				referendum_index,
@@ -551,7 +550,6 @@ pub mod pallet {
 			let ownership = Share::Pallet::<T>::virtual_acc(collection_id, asset_id);
 			ensure!(ownership.is_some(), Error::<T>::NotAnAsset);
 
-			
 			//Compare guaranty payment amount+fees with tenant free_balance
 			let guaranty = Self::calculate_guaranty(collection_id, asset_id);
 			let fee0 = Self::manage_bal_to_u128(T::RepFees::get()).unwrap();

--- a/pallets/asset_management/src/lib.rs
+++ b/pallets/asset_management/src/lib.rs
@@ -439,8 +439,8 @@ pub mod pallet {
 			let bals0 = BalanceType::<T>::convert_to_balance(token0);
 			let token1 = bals0.dem_bal;
 
-			let v = Dem::Vote { aye: vote, conviction: Dem::Conviction::Locked1x };
-
+			//let v = Dem::Vote { aye: vote, conviction: Dem::Conviction::Locked1x };
+			let v = Self::vote_helper(token0,vote).unwrap();
 			Dem::Pallet::<T>::vote(
 				origin.clone(),
 				referendum_index,

--- a/pallets/asset_management/src/tests.rs
+++ b/pallets/asset_management/src/tests.rs
@@ -362,6 +362,26 @@ fn share_distributor0() {
 		let tenant0 = RoleModule::tenants(GERARD).unwrap();
 		assert!(tenant0.asset_account.is_none());
 
+
+		// Gerard is not a registered tenant
+		assert_err!(AssetManagement::launch_tenant_session(
+			origin_ferdie.clone(),
+			NftColl::OFFICESTEST,
+			item_id0,
+			GERARD,
+			VoteProposals::Election,
+			Ident::Judgement::Reasonable,
+		),
+		Error::<Test>::NotARegisteredTenant);
+
+
+		//change Gerard to a RegisteredTenant
+		Roles::TenantLog::<Test>::mutate(GERARD, |val| {
+			let mut val0 = val.clone().unwrap();
+			val0.registered = true;
+			*val = Some(val0);
+		});
+
 		/***	START: Successful scenario of proposing a tenant    ** */
 		// Create a voting session, aka referendum to propose GERARD as a tenant for the first house
 		assert_ok!(AssetManagement::launch_tenant_session(
@@ -441,6 +461,12 @@ fn share_distributor0() {
 		);
 		println!("\n\nlaunch_tenant_session - : THE TENANT IS ALREADY LINKED WITH AN ASSET");
 
+		//change PEGGY to a RegisteredTenant
+		Roles::TenantLog::<Test>::mutate(PEGGY, |val| {
+			let mut val0 = val.clone().unwrap();
+			val0.registered = true;
+			*val = Some(val0);
+		});
 		//Ferdie proposes PEGGY, but Peggy does not have enough funds
 		assert_err!(
 			AssetManagement::launch_tenant_session(
@@ -454,6 +480,13 @@ fn share_distributor0() {
 			Error::<Test>::NotEnoughTenantFunds
 		);
 		println!("\n\nlaunch_tenant_session - : THE TENANT IS ALREADY LINKED WITH AN ASSET");
+
+		//change HUNTER to a RegisteredTenant
+		Roles::TenantLog::<Test>::mutate(HUNTER, |val| {
+			let mut val0 = val.clone().unwrap();
+			val0.registered = true;
+			*val = Some(val0);
+		});
 
 		// demote a tenant
 		assert_err!(

--- a/pallets/asset_management/src/tests.rs
+++ b/pallets/asset_management/src/tests.rs
@@ -362,18 +362,18 @@ fn share_distributor0() {
 		let tenant0 = RoleModule::tenants(GERARD).unwrap();
 		assert!(tenant0.asset_account.is_none());
 
-
 		// Gerard is not a registered tenant
-		assert_err!(AssetManagement::launch_tenant_session(
-			origin_ferdie.clone(),
-			NftColl::OFFICESTEST,
-			item_id0,
-			GERARD,
-			VoteProposals::Election,
-			Ident::Judgement::Reasonable,
-		),
-		Error::<Test>::NotARegisteredTenant);
-
+		assert_err!(
+			AssetManagement::launch_tenant_session(
+				origin_ferdie.clone(),
+				NftColl::OFFICESTEST,
+				item_id0,
+				GERARD,
+				VoteProposals::Election,
+				Ident::Judgement::Reasonable,
+			),
+			Error::<Test>::NotARegisteredTenant
+		);
 
 		//change Gerard to a RegisteredTenant
 		Roles::TenantLog::<Test>::mutate(GERARD, |val| {

--- a/pallets/roles/src/lib.rs
+++ b/pallets/roles/src/lib.rs
@@ -357,7 +357,7 @@ pub mod pallet {
 		}
 
 		#[pallet::weight(<T as pallet::Config>::WeightInfo::approval(5))]
-		///Approval function for Sellers and Servicers. Only for admin level.
+		///Approval function for Sellers, Servicers, and Notary. Only for admin level.
 		pub fn account_approval(origin: OriginFor<T>, account: T::AccountId) -> DispatchResult {
 			let sender = ensure_signed(origin)?;
 			ensure!(

--- a/pallets/roles/src/tests.rs
+++ b/pallets/roles/src/tests.rs
@@ -40,6 +40,7 @@ fn test_struct_methods() {
 				contract_start: System::block_number(),
 				remaining_rent: 0,
 				remaining_payments: 0,
+				registered: false,
 			})
 		);
 

--- a/pallets/roles/src/types.rs
+++ b/pallets/roles/src/types.rs
@@ -130,6 +130,7 @@ pub struct Tenant<T: Config> {
 	pub contract_start: BlockNumberOf<T>,
 	pub remaining_rent: BalanceOf<T>,
 	pub remaining_payments: u8,
+	pub registered: bool,
 }
 impl<T: Config> Tenant<T> {
 	pub fn new(acc: OriginFor<T>) -> DispatchResult {
@@ -143,6 +144,7 @@ impl<T: Config> Tenant<T> {
 			contract_start: now,
 			remaining_rent: Zero::zero(),
 			remaining_payments: 0,
+			registered: false,
 		};
 		TenantLog::<T>::insert(caller, &tenant);
 		Ok(())

--- a/pallets/roles/src/types.rs
+++ b/pallets/roles/src/types.rs
@@ -101,12 +101,13 @@ where
 		let now = <frame_system::Pallet<T>>::block_number();
 		ensure!(!HouseSellerLog::<T>::contains_key(&caller), Error::<T>::NoneValue);
 
-		let hw = HouseSeller { account_id: caller.clone(), age: now, activated: false, verifier: admin };
+		let hw =
+			HouseSeller { account_id: caller.clone(), age: now, activated: false, verifier: admin };
 
 		SellerApprovalList::<T>::mutate(|list| {
 			list.push(hw);
 		});
-		RequestedRoles::<T>::insert(caller,Accounts::SELLER);
+		RequestedRoles::<T>::insert(caller, Accounts::SELLER);
 
 		Ok(())
 	}
@@ -169,12 +170,13 @@ impl<T: Config> Servicer<T> {
 		let caller = ensure_signed(acc)?;
 		let admin = SUDO::Pallet::<T>::key().unwrap();
 		let now = <frame_system::Pallet<T>>::block_number();
-		let sv = Servicer { account_id: caller.clone(), age: now, activated: false, verifier: admin };
+		let sv =
+			Servicer { account_id: caller.clone(), age: now, activated: false, verifier: admin };
 
 		ServicerApprovalList::<T>::mutate(|list| {
 			list.push(sv);
 		});
-		RequestedRoles::<T>::insert(caller,Accounts::SERVICER);
+		RequestedRoles::<T>::insert(caller, Accounts::SERVICER);
 		Ok(())
 	}
 }
@@ -250,11 +252,12 @@ where
 		ensure!(!NotaryLog::<T>::contains_key(&caller), Error::<T>::NoneValue);
 
 		let admin = SUDO::Pallet::<T>::key().unwrap();
-		let notary = Notary { account_id: caller.clone(), age: now, activated: false, verifier: admin };
+		let notary =
+			Notary { account_id: caller.clone(), age: now, activated: false, verifier: admin };
 		NotaryApprovalList::<T>::mutate(|list| {
 			list.push(notary);
 		});
-		RequestedRoles::<T>::insert(caller,Accounts::NOTARY);
+		RequestedRoles::<T>::insert(caller, Accounts::NOTARY);
 
 		Ok(())
 	}

--- a/pallets/roles/src/types.rs
+++ b/pallets/roles/src/types.rs
@@ -101,11 +101,12 @@ where
 		let now = <frame_system::Pallet<T>>::block_number();
 		ensure!(!HouseSellerLog::<T>::contains_key(&caller), Error::<T>::NoneValue);
 
-		let hw = HouseSeller { account_id: caller, age: now, activated: false, verifier: admin };
+		let hw = HouseSeller { account_id: caller.clone(), age: now, activated: false, verifier: admin };
 
 		SellerApprovalList::<T>::mutate(|list| {
 			list.push(hw);
 		});
+		RequestedRoles::<T>::insert(caller,Accounts::SELLER);
 
 		Ok(())
 	}
@@ -166,11 +167,12 @@ impl<T: Config> Servicer<T> {
 		let caller = ensure_signed(acc)?;
 		let admin = SUDO::Pallet::<T>::key().unwrap();
 		let now = <frame_system::Pallet<T>>::block_number();
-		let sv = Servicer { account_id: caller, age: now, activated: false, verifier: admin };
+		let sv = Servicer { account_id: caller.clone(), age: now, activated: false, verifier: admin };
 
 		ServicerApprovalList::<T>::mutate(|list| {
 			list.push(sv);
 		});
+		RequestedRoles::<T>::insert(caller,Accounts::SERVICER);
 		Ok(())
 	}
 }
@@ -246,10 +248,11 @@ where
 		ensure!(!NotaryLog::<T>::contains_key(&caller), Error::<T>::NoneValue);
 
 		let admin = SUDO::Pallet::<T>::key().unwrap();
-		let notary = Notary { account_id: caller, age: now, activated: false, verifier: admin };
+		let notary = Notary { account_id: caller.clone(), age: now, activated: false, verifier: admin };
 		NotaryApprovalList::<T>::mutate(|list| {
 			list.push(notary);
 		});
+		RequestedRoles::<T>::insert(caller,Accounts::NOTARY);
 
 		Ok(())
 	}

--- a/pallets/tenancy/src/lib.rs
+++ b/pallets/tenancy/src/lib.rs
@@ -173,7 +173,7 @@ pub mod pallet {
 			let caller = ensure_signed(origin.clone())?;
 			// Ensure that the caller has the tenancy role
 			ensure!(Roles::TenantLog::<T>::contains_key(caller.clone()), Error::<T>::NotATenant);
-			RegisteredTenant::<T>::new(caller.clone(),info.clone()).ok();
+			RegisteredTenant::<T>::new(caller.clone(), info.clone()).ok();
 
 			// Ensure that the asset is valid
 			let collection_id: T::NftCollectionId = asset_type.value().into();

--- a/pallets/tenancy/src/lib.rs
+++ b/pallets/tenancy/src/lib.rs
@@ -173,6 +173,7 @@ pub mod pallet {
 			let caller = ensure_signed(origin.clone())?;
 			// Ensure that the caller has the tenancy role
 			ensure!(Roles::TenantLog::<T>::contains_key(caller.clone()), Error::<T>::NotATenant);
+			RegisteredTenant::<T>::new(caller.clone(),info.clone()).ok();
 
 			// Ensure that the asset is valid
 			let collection_id: T::NftCollectionId = asset_type.value().into();

--- a/pallets/tenancy/src/types.rs
+++ b/pallets/tenancy/src/types.rs
@@ -43,7 +43,12 @@ impl<T: Config> RegisteredTenant<T> {
 	) -> DispatchResult {
 		let registered_at_block = <frame_system::Pallet<T>>::block_number();
 		let tenant = RegisteredTenant::<T> { infos, registered_at_block };
-		Tenants::<T>::insert(tenant_id, tenant);
+		Tenants::<T>::insert(tenant_id.clone(), tenant);
+		Roles::TenantLog::<T>::mutate(tenant_id, |val| {
+			let mut val0 = val.clone().unwrap();
+			val0.registered = true;
+			*val = Some(val0);
+		});
 		Ok(())
 	}
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -174,7 +174,7 @@ parameter_types! {
 
 impl frame_system::Config for Runtime {
 	/// The basic call filter to use in dispatchable.
-	type BaseCallFilter = frame_support::traits::Everything;
+	type BaseCallFilter = DontAllowCollectiveAndDemocracy;
 	/// Block & extrinsics weights: base values and limits.
 	type BlockWeights = RuntimeBlockWeights;
 	/// The maximum length of a block (in bytes).


### PR DESCRIPTION
The new `RequestedRoles` storage was not being updated, and as a result, new roles requests (seller, servicer) were not found.
I also updated the Notary role creation to use this storage, as there is currently no referendum system similar to the one used for Representatives.
One Question remains:
with the use of `RequestedRoles` storage for Approval to facilitate the front-end design, `NotaryApprovalList`, `SellerApprovalList`, and `ServicerApprovalList` storages are no used anymore. This needs to be clarified... 