### PR TITLE
Add `requested_asset` to Registered_Tenant Struct

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -192,8 +192,8 @@ fn testnet_genesis(
 		role_module: RoleModuleConfig {
 			new_admin: Some(get_account_id_from_seed::<sr25519::Public>("Alice")),
 			representatives: vec![
-				get_account_id_from_seed::<sr25519::Public>("Gabriel"),
-				get_account_id_from_seed::<sr25519::Public>("Henry"),
+				//get_account_id_from_seed::<sr25519::Public>("Gabriel"),
+				//get_account_id_from_seed::<sr25519::Public>("Henry"),
 			],
 		},
 		nft_module: NftModuleConfig {

--- a/pallets/asset_management/src/functions.rs
+++ b/pallets/asset_management/src/functions.rs
@@ -224,11 +224,8 @@ impl<T: Config> Pallet<T> {
 
 		let proposal_hash = T::Hashing::hash_of(&call_dispatch);
 		let proposal_encoded: Vec<u8> = call_dispatch.encode();
-		match Dem::Pallet::<T>::note_preimage(origin, proposal_encoded) {
-			Ok(_) => (),
-			Err(x) if x == Error::<T>::DuplicatePreimage.into() => (),
-			Err(x) => panic!("{x:?}"),
-		}
+		Dem::Pallet::<T>::note_preimage(origin, proposal_encoded).ok();
+		
 		proposal_hash
 	}
 

--- a/pallets/asset_management/src/functions.rs
+++ b/pallets/asset_management/src/functions.rs
@@ -50,8 +50,9 @@ impl<T: Config> Pallet<T> {
 		}
 
 		if !check0 {
+			let origin_root: OriginFor<T> = frame_system::RawOrigin::Root.into();
 			//Set the representative as a registrar
-			Ident::Pallet::<T>::add_registrar(origin, who2).ok();
+			Ident::Pallet::<T>::add_registrar(origin_root, who2).ok();
 
 			//Set registrar fields
 			let origin2: OriginFor<T> = RawOrigin::Signed(who).into();

--- a/pallets/asset_management/src/lib.rs
+++ b/pallets/asset_management/src/lib.rs
@@ -271,8 +271,6 @@ pub mod pallet {
 		StorageOverflow,
 		/// The proposal could not be created
 		FailedToCreateProposal,
-		/// This Preimage already exists
-		DuplicatePreimage,
 		/// Not an owner in the corresponding virtual account
 		NotAnOwner,
 		/// The Asset Does not Exists

--- a/pallets/tenancy/src/types.rs
+++ b/pallets/tenancy/src/types.rs
@@ -34,15 +34,19 @@ pub struct RegisteredTenant<T: Config> {
 	pub infos: Box<IdentityInfo<T::MaxAdditionalFields>>,
 	///Creation Blocknumber
 	pub registered_at_block: BlockNumberOf<T>,
+	///Asset requested by the tenant
+	pub asset_requested: Option<T::AccountId>,
 }
 
 impl<T: Config> RegisteredTenant<T> {
 	pub fn new(
 		tenant_id: T::AccountId,
 		infos: Box<IdentityInfo<T::MaxAdditionalFields>>,
+		asset_requested: Option<T::AccountId>,
+
 	) -> DispatchResult {
 		let registered_at_block = <frame_system::Pallet<T>>::block_number();
-		let tenant = RegisteredTenant::<T> { infos, registered_at_block };
+		let tenant = RegisteredTenant::<T> { infos, registered_at_block,asset_requested};
 		Tenants::<T>::insert(tenant_id.clone(), tenant);
 		Roles::TenantLog::<T>::mutate(tenant_id, |val| {
 			let mut val0 = val.clone().unwrap();


### PR DESCRIPTION
- Fixed PreImage bug
- Fixed Registrar addition
- Added field `requested_asset` to struct `Registered_Tenant` in pallet tenancy. This struct can be accessed through the storage Tenants. 
- Removed Representative initialisation at genesis to prevent wrong index in pallet Identity. 